### PR TITLE
Detect and prevent circular dependencies in decorators

### DIFF
--- a/DecoratR.Tests/CircularDependency.Tests.cs
+++ b/DecoratR.Tests/CircularDependency.Tests.cs
@@ -1,0 +1,142 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace DecoratR.Tests;
+
+[TestFixture]
+public class CircularDependencyTests
+{
+    [Test]
+    public void Apply_ThrowsException_WhenSameDecoratorTypeAppearsMultipleTimes()
+    {
+        var services = new ServiceCollection();
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+        {
+            services.Decorate<IService>()
+                    .With<LoggingDecorator>()     // First occurrence
+                    .Then<RetryDecorator>()
+                    .Then<LoggingDecorator>()     // Duplicate - should throw
+                    .Then<BaseService>()
+                    .Apply();
+        });
+
+        Assert.That(ex.Message, Does.Contain("Circular dependency detected"));
+        Assert.That(ex.Message, Does.Contain("LoggingDecorator"));
+        Assert.That(ex.Message, Does.Contain("appear multiple times"));
+    }
+
+    [Test]
+    public void Apply_ThrowsException_WhenDecoratorHasCircularConstructorDependency()
+    {
+        var services = new ServiceCollection();
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+        {
+            services.Decorate<IService>()
+                    .With<CircularDependencyDecorator>()
+                    .Then<BaseService>()
+                    .Apply();
+        });
+
+        Assert.That(ex.Message, Does.Contain("Circular dependency detected"));
+        Assert.That(ex.Message, Does.Contain("CircularDependencyDecorator"));
+    }
+
+    [Test]
+    public void Apply_ThrowsException_WhenDecoratorHasGenericCircularDependency()
+    {
+        var services = new ServiceCollection();
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+        {
+            services.Decorate<IService>()
+                    .With<GenericCircularDependencyDecorator>()
+                    .Then<BaseService>()
+                    .Apply();
+        });
+
+        Assert.That(ex.Message, Does.Contain("Potential circular dependency detected"));
+        Assert.That(ex.Message, Does.Contain("generic argument"));
+    }
+
+    [Test]
+    public void Apply_DoesNotThrow_WhenDecoratorChainIsValid()
+    {
+        var services = new ServiceCollection();
+
+        Assert.DoesNotThrow(() =>
+        {
+            services.Decorate<IService>()
+                    .With<LoggingDecorator>()
+                    .Then<RetryDecorator>()
+                    .Then<BaseService>()
+                    .Apply();
+        });
+    }
+
+    [Test]
+    public void Apply_AllowsFactoryDecorators_EvenWithDuplicateTypes()
+    {
+        var services = new ServiceCollection();
+
+        // Factory decorators should be allowed even if they create similar functionality
+        // because they might have different behavior based on runtime conditions
+        Assert.DoesNotThrow(() =>
+        {
+            services.Decorate<IService>()
+                    .With((sp, inner) => new LoggingDecorator(inner))
+                    .Then((sp, inner) => new LoggingDecorator(inner)) // Different factory instance
+                    .Then<BaseService>()
+                    .Apply();
+        });
+    }
+}
+
+// Test decorators for circular dependency testing
+public class CircularDependencyDecorator : IService
+{
+    private readonly IService _inner;
+    private readonly IService _circularDep; // This creates a circular dependency!
+
+    public CircularDependencyDecorator(IService inner, IService circularDep)
+    {
+        _inner = inner;
+        _circularDep = circularDep;
+    }
+
+    public string Execute() => $"Circular({_inner.Execute()})";
+}
+
+public class GenericCircularDependencyDecorator : IService
+{
+    private readonly IService _inner;
+    private readonly ILogger<IService> _logger; // Generic type containing IService
+
+    public GenericCircularDependencyDecorator(IService inner, ILogger<IService> logger)
+    {
+        _inner = inner;
+        _logger = logger;
+    }
+
+    public string Execute() => $"GenericCircular({_inner.Execute()})";
+}
+
+// Valid decorator for comparison
+public class ValidDecoratorWithDependencies : IService
+{
+    private readonly IService _inner;
+    private readonly ILogger<ValidDecoratorWithDependencies> _logger;
+
+    public ValidDecoratorWithDependencies(IService inner, ILogger<ValidDecoratorWithDependencies> logger)
+    {
+        _inner = inner;
+        _logger = logger;
+    }
+
+    public string Execute()
+    {
+        _logger.LogInformation("Executing ValidDecorator");
+        return $"Valid({_inner.Execute()})";
+    }
+}

--- a/Examples/CircularDependencyExample.cs
+++ b/Examples/CircularDependencyExample.cs
@@ -1,0 +1,151 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace DecoratR.Examples;
+
+// Let's say we have these services
+public interface IOrderService
+{
+    Task<Order> ProcessOrderAsync(int orderId);
+}
+
+public interface IAuditService
+{
+    Task LogOrderProcessingAsync(int orderId, string action);
+}
+
+public interface INotificationService
+{
+    Task SendOrderNotificationAsync(int orderId);
+}
+
+public class Order
+{
+    public int Id { get; set; }
+    public string CustomerName { get; set; } = "";
+    public decimal Amount { get; set; }
+}
+
+// Base implementation
+public class OrderService : IOrderService
+{
+    public async Task<Order> ProcessOrderAsync(int orderId)
+    {
+        // Process the order
+        await Task.Delay(100); // Simulate processing
+        return new Order { Id = orderId, CustomerName = "John Doe", Amount = 100.50m };
+    }
+}
+
+// This decorator has a HIDDEN circular dependency
+public class AuditDecorator : IOrderService
+{
+    private readonly IOrderService _inner;
+    private readonly IAuditService _auditService; // This is where the problem starts!
+
+    public AuditDecorator(IOrderService inner, IAuditService auditService)
+    {
+        _inner = inner;
+        _auditService = auditService;
+    }
+
+    public async Task<Order> ProcessOrderAsync(int orderId)
+    {
+        await _auditService.LogOrderProcessingAsync(orderId, "Starting");
+        var result = await _inner.ProcessOrderAsync(orderId);
+        await _auditService.LogOrderProcessingAsync(orderId, "Completed");
+        return result;
+    }
+}
+
+// Here's the problematic audit service that creates the circular dependency
+public class ProblematicAuditService : IAuditService
+{
+    private readonly IOrderService _orderService; // CIRCULAR DEPENDENCY!
+    private readonly ILogger<ProblematicAuditService> _logger;
+
+    public ProblematicAuditService(IOrderService orderService, ILogger<ProblematicAuditService> logger)
+    {
+        _orderService = orderService; // This depends back on IOrderService!
+        _logger = logger;
+    }
+
+    public async Task LogOrderProcessingAsync(int orderId, string action)
+    {
+        // Maybe the audit service wants to get order details for logging
+        var order = await _orderService.ProcessOrderAsync(orderId); // This creates infinite loop!
+        _logger.LogInformation($"Order {order.Id} for {order.CustomerName}: {action}");
+    }
+}
+
+// A better audit service without circular dependency
+public class GoodAuditService : IAuditService
+{
+    private readonly ILogger<GoodAuditService> _logger;
+
+    public GoodAuditService(ILogger<GoodAuditService> logger)
+    {
+        _logger = logger; // Only depends on logging, not on IOrderService
+    }
+
+    public async Task LogOrderProcessingAsync(int orderId, string action)
+    {
+        _logger.LogInformation($"Order {orderId}: {action}");
+        await Task.CompletedTask;
+    }
+}
+
+public static class CircularDependencyExample
+{
+    public static void DemonstrateCircularDependencyProblem()
+    {
+        var services = new ServiceCollection();
+        
+        // Register the problematic audit service
+        services.AddScoped<IAuditService, ProblematicAuditService>();
+        services.AddLogging();
+
+        // This will create a circular dependency when the container tries to resolve IOrderService:
+        // 1. Container tries to create AuditDecorator
+        // 2. AuditDecorator needs IAuditService
+        // 3. ProblematicAuditService needs IOrderService  
+        // 4. But IOrderService is the AuditDecorator we're trying to create!
+        // 5. INFINITE LOOP / STACK OVERFLOW!
+        
+        services.Decorate<IOrderService>()
+                .With<AuditDecorator>()           // This decorator depends on IAuditService
+                .Then<OrderService>()             // Base implementation
+                .Apply();
+
+        var provider = services.BuildServiceProvider();
+        
+        // This will throw a stack overflow exception or circular dependency error
+        try
+        {
+            var orderService = provider.GetRequiredService<IOrderService>();
+            // BOOM! 💥 Circular dependency at runtime
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Circular dependency detected: {ex.Message}");
+        }
+    }
+
+    public static void DemonstrateProperImplementation()
+    {
+        var services = new ServiceCollection();
+        
+        // Register the good audit service (no circular dependency)
+        services.AddScoped<IAuditService, GoodAuditService>();
+        services.AddLogging();
+
+        // This works fine because GoodAuditService doesn't depend on IOrderService
+        services.Decorate<IOrderService>()
+                .With<AuditDecorator>()
+                .Then<OrderService>()
+                .Apply();
+
+        var provider = services.BuildServiceProvider();
+        var orderService = provider.GetRequiredService<IOrderService>(); // ✅ Works perfectly!
+    }
+}


### PR DESCRIPTION
Adds validation logic to DecorationBuilder to detect duplicate decorator types and potential circular dependencies in constructor parameters, including generic types. Includes new tests for circular dependency scenarios and an example demonstrating the issue and proper implementation.